### PR TITLE
Fixing how to parse the backup dir from the ipa-backup output

### DIFF
--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -27,7 +27,7 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-27/test_backup_and_restore:
+  fedora-27/test_backup_and_restore_TestBackupAndRestore:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -40,7 +40,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:
+  fedora-27/test_backup_and_restore:_BaseBackupAndRestoreWithDNS:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -53,7 +53,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:
+  fedora-27/test_backup_and_restore:_TestBackupAndRestoreWithDNS:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -66,7 +66,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:
+  fedora-27/test_backup_and_restore:_TestBackupReinstallRestoreWithDNS:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -79,7 +79,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:
+  fedora-27/test_backup_and_restore:_BaseBackupAndRestoreWithDNSSEC:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -92,7 +92,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:
+  fedora-27/test_backup_and_restore:_TestBackupAndRestoreWithDNSSEC:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -105,7 +105,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:
+  fedora-27/test_backup_and_restore:_TestBackupReinstallRestoreWithDNSSEC:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -118,7 +118,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:
+  fedora-27/test_backup_and_restore:_TestBackupAndRestoreWithKRA:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -131,7 +131,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:
+  fedora-27/test_backup_and_restore:_TestBackupReinstallRestoreWithKRA:
     requires: [fedora-27/build]
     priority: 50
     job:

--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -27,7 +27,7 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-27/test_backup_and_restore_TestBackupAndRestore:
+  TestBackupAndRestore:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -40,20 +40,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:_BaseBackupAndRestoreWithDNS:
-    requires: [fedora-27/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-27/build_url}'
-        test_suite:   test_integration/test_backup_and_restore.py::BaseBackupAndRestoreWithDNS
-        template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl
-
-
-  fedora-27/test_backup_and_restore:_TestBackupAndRestoreWithDNS:
+  TestBackupAndRestoreWithDNS:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -66,7 +53,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:_TestBackupReinstallRestoreWithDNS:
+  TestBackupReinstallRestoreWithDNS:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -79,20 +66,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:_BaseBackupAndRestoreWithDNSSEC:
-    requires: [fedora-27/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-27/build_url}'
-        test_suite:   test_integration/test_backup_and_restore.py::BaseBackupAndRestoreWithDNSSEC
-        template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl
-
-
-  fedora-27/test_backup_and_restore:_TestBackupAndRestoreWithDNSSEC:
+  TestBackupAndRestoreWithDNSSEC:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -105,7 +79,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:_TestBackupReinstallRestoreWithDNSSEC:
+  TestBackupReinstallRestoreWithDNSSEC:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -118,7 +92,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:_TestBackupAndRestoreWithKRA:
+  TestBackupAndRestoreWithKRA:
     requires: [fedora-27/build]
     priority: 50
     job:
@@ -131,7 +105,7 @@ jobs:
         topology: *master_1repl
 
 
-  fedora-27/test_backup_and_restore:_TestBackupReinstallRestoreWithKRA:
+  TestBackupReinstallRestoreWithKRA:
     requires: [fedora-27/build]
     priority: 50
     job:

--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -27,38 +27,15 @@ jobs:
         timeout: 1800
         topology: *build
 
-  fedora-27/simple_replication:
+  fedora-27/test_backup_and_restore:
     requires: [fedora-27/build]
     priority: 50
     job:
       class: RunPytest
       args:
         build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_simple_replication.py
+        test_suite:   test_integration/test_backup_and_restore.py
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl
 
-  fedora-27/caless:
-    requires: [fedora-27/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_caless.py::TestServerReplicaCALessToCAFull
-        template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl
-
-  fedora-27/external_ca:
-    requires: [fedora-27/build]
-    priority: 50
-    job:
-      class: RunPytest
-      args:
-        build_url: '{fedora-27/build_url}'
-        test_suite: test_integration/test_external_ca.py::TestExternalCA
-        template: *ci-master-f27
-        timeout: 3600
-        topology: *master_1repl

--- a/.freeipa-pr-ci.yaml
+++ b/.freeipa-pr-ci.yaml
@@ -34,8 +34,111 @@ jobs:
       class: RunPytest
       args:
         build_url: '{fedora-27/build_url}'
-        test_suite:   test_integration/test_backup_and_restore.py
+        test_suite:   test_integration/test_backup_and_restore.py::TestBackupAndRestore
         template: *ci-master-f27
         timeout: 3600
         topology: *master_1repl
 
+
+  fedora-27/test_backup_and_restore:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite:   test_integration/test_backup_and_restore.py::BaseBackupAndRestoreWithDNS
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+
+  fedora-27/test_backup_and_restore:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite:   test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNS
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+
+  fedora-27/test_backup_and_restore:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite:   test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNS
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+
+  fedora-27/test_backup_and_restore:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite:   test_integration/test_backup_and_restore.py::BaseBackupAndRestoreWithDNSSEC
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+
+  fedora-27/test_backup_and_restore:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite:   test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithDNSSEC
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+
+  fedora-27/test_backup_and_restore:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite:   test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithDNSSEC
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+
+  fedora-27/test_backup_and_restore:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite:   test_integration/test_backup_and_restore.py::TestBackupAndRestoreWithKRA
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl
+
+
+  fedora-27/test_backup_and_restore:
+    requires: [fedora-27/build]
+    priority: 50
+    job:
+      class: RunPytest
+      args:
+        build_url: '{fedora-27/build_url}'
+        test_suite:   test_integration/test_backup_and_restore.py::TestBackupReinstallRestoreWithKRA
+        template: *ci-master-f27
+        timeout: 3600
+        topology: *master_1repl

--- a/ipatests/test_integration/test_backup_and_restore.py
+++ b/ipatests/test_integration/test_backup_and_restore.py
@@ -126,8 +126,7 @@ def backup(host):
 
     # Get the backup location from the command's output
     for line in result.stderr_text.splitlines():
-        prefix = ('ipa.ipaserver.install.ipa_backup.Backup: '
-                  'INFO: Backed up to ')
+        prefix = ('ipaserver.install.ipa_backup: INFO: Backed up to')
         if line.startswith(prefix):
             backup_path = line[len(prefix):].strip()
             logger.info('Backup path for %s is %s', host, backup_path)


### PR DESCRIPTION
Fixing how the test_backup_and_restore.py suite parses the output
from the `ipa-backup -v` command in order to get the backup directory.

Fixes: #7339